### PR TITLE
add stack trace to panic recovery logging in single.go

### DIFF
--- a/pkg/periodictask/interface.go
+++ b/pkg/periodictask/interface.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+var StackTraceLogField = "stack-trace"
+
 type Coordinator interface {
 	locker.Locker
 

--- a/pkg/periodictask/single.go
+++ b/pkg/periodictask/single.go
@@ -3,6 +3,7 @@ package periodictask
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -80,7 +81,10 @@ func (r *PeriodicSingleTaskRunner) start(ctx context.Context) {
 	defer r.terminate()
 	defer func() {
 		if err, ok := recover().(error); ok {
-			aulogging.Logger.Ctx(ctx).Error().WithErr(err).Printf("periodic-task runner '%s' exited due to panic: %+v", r.taskKey, errors.New(fmt.Sprintf("%v", err)))
+			aulogging.Logger.Ctx(ctx).Error().
+				WithErr(err).
+				With(StackTraceLogField, string(debug.Stack())).
+				Printf("periodic-task runner '%s' exited due to panic: %+v", r.taskKey, errors.New(fmt.Sprintf("%v", err)))
 		}
 	}()
 	r.performTask(ctx)


### PR DESCRIPTION
- Adds the stack trace to the error logging if a panic is recovered during `performTask` of PeriodicSingleTaskRunner
- Adds global `var StackTraceLogField` to periodictask interface.go